### PR TITLE
Add DbContext null check to FieldInterceptor.cs

### DIFF
--- a/src/EntityFramework.Filters/FilterInterceptor.cs
+++ b/src/EntityFramework.Filters/FilterInterceptor.cs
@@ -1,4 +1,4 @@
-﻿namespace EntityFramework.Filters
+namespace EntityFramework.Filters
 {
     using System.Data.Entity.Core.Common.CommandTrees;
     using System.Data.Entity.Core.Metadata.Edm;
@@ -14,10 +14,14 @@
                 var queryCommand = interceptionContext.Result as DbQueryCommandTree;
                 if (queryCommand != null)
                 {
-                    var newQuery =
-                        queryCommand.Query.Accept(new FilterQueryVisitor(interceptionContext.DbContexts.First()));
-                    interceptionContext.Result = new DbQueryCommandTree(
-                        queryCommand.MetadataWorkspace, queryCommand.DataSpace, newQuery);
+                    var context = interceptionContext.DbContexts.FirstOrDefault();
+                    if (context != null)
+                    {
+                        var newQuery =
+                            queryCommand.Query.Accept(new FilterQueryVisitor(context));
+                        interceptionContext.Result = new DbQueryCommandTree(
+                            queryCommand.MetadataWorkspace, queryCommand.DataSpace, newQuery);
+                    }
                 }
             }
         }


### PR DESCRIPTION
In some cases (outlined under "caveat" here, http://entityframework.codeplex.com/wikipage?title=Interception) EntityFramework interceptors may not have any DbContexts associated with them.  The current code will cause a null reference exception.  This can be replicated by using a profiling tool such as Glimpse.EF6 with a project using EntityFramework.Filters.  This PR adds a null check for context before continuing with filter execution.
