### PR TITLE
Skip FilterQueryVisitor when can't find config metadata

### DIFF
--- a/src/EntityFramework.Filters/FilterQueryVisitor.cs
+++ b/src/EntityFramework.Filters/FilterQueryVisitor.cs
@@ -25,7 +25,12 @@ namespace EntityFramework.Filters
         public override DbExpression Visit(DbScanExpression expression)
         {
             // a bit harder to get the metadata in CSpace
-            var item = expression.Target.ElementType.MetadataProperties.First(p => p.Name == "Configuration");
+            var item = expression.Target.ElementType.MetadataProperties.FirstOrDefault(p => p.Name == "Configuration");
+            
+            if(item == null)
+            {
+                return base.Visit(expression);
+            }
 
             // using reflection to get the Annotations property as EntityTtypeConfiguration is an internal class in EF
             Dictionary<string, object> annotations = new Dictionary<string, object>();


### PR DESCRIPTION
Depending on the Association Type, the ElementType might not have a configuration metadata property, what caused the visitor to blow up.
