### PR TITLE
Preserve value of UseDatabaseNullSemantics

### DIFF
--- a/src/EntityFramework.Filters.Example/EntityFramework.Filters.Example.csproj
+++ b/src/EntityFramework.Filters.Example/EntityFramework.Filters.Example.csproj
@@ -30,11 +30,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/EntityFramework.Filters.Example/packages.config
+++ b/src/EntityFramework.Filters.Example/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.0" targetFramework="net451" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net451" />
 </packages>

--- a/src/EntityFramework.Filters.Tests/EntityFramework.Filters.Tests.csproj
+++ b/src/EntityFramework.Filters.Tests/EntityFramework.Filters.Tests.csproj
@@ -30,11 +30,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/EntityFramework.Filters.Tests/packages.config
+++ b/src/EntityFramework.Filters.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.0" targetFramework="net451" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
 </packages>

--- a/src/EntityFramework.Filters/EntityFramework.Filters.csproj
+++ b/src/EntityFramework.Filters/EntityFramework.Filters.csproj
@@ -32,12 +32,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net40\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\EntityFramework.6.1.0\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net40\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/EntityFramework.Filters/FilterInterceptor.cs
+++ b/src/EntityFramework.Filters/FilterInterceptor.cs
@@ -9,21 +9,20 @@ namespace EntityFramework.Filters
     {
         public void TreeCreated(DbCommandTreeInterceptionContext interceptionContext)
         {
-            if (interceptionContext.OriginalResult.DataSpace == DataSpace.CSpace)
-            {
-                var queryCommand = interceptionContext.Result as DbQueryCommandTree;
-                if (queryCommand != null)
-                {
-                    var context = interceptionContext.DbContexts.FirstOrDefault();
-                    if (context != null)
-                    {
-                        var newQuery =
-                            queryCommand.Query.Accept(new FilterQueryVisitor(context));
-                        interceptionContext.Result = new DbQueryCommandTree(
-                            queryCommand.MetadataWorkspace, queryCommand.DataSpace, newQuery);
-                    }
-                }
-            }
+            if (interceptionContext.OriginalResult.DataSpace != DataSpace.CSpace) return;
+
+            var queryCommand = interceptionContext.Result as DbQueryCommandTree;
+            if (queryCommand == null) return;
+
+            var context = interceptionContext.DbContexts.FirstOrDefault();
+            if (context == null) return;
+
+            interceptionContext.Result = new DbQueryCommandTree(
+                queryCommand.MetadataWorkspace,
+                queryCommand.DataSpace,
+                queryCommand.Query.Accept(new FilterQueryVisitor(context)),
+                validate: true,
+                useDatabaseNullSemantics: queryCommand.UseDatabaseNullSemantics);
         }
     }
 }

--- a/src/EntityFramework.Filters/packages.config
+++ b/src/EntityFramework.Filters/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.1.0" targetFramework="net40" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The interceptor was using the 3 parameter constructor for DbQueryCommandTree. This defaults the value of UseDatabaseNullSemantics to true. This change makes it use the value from the intercepted query.

Also upgraded to EF 6.1.3 (from 6.1.0).

Finally, the Nuget package is slightly behind the code. I don't think it includes this commit:

https://github.com/jbogard/EntityFramework.Filters/commit/c100a6e87d7e9cc172f4558d62e4d9d61dbbbff5

Please would it be possible to release an updated package?